### PR TITLE
Add fundamental data utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Analytics-Portfolio folder has:
 classes
     market_data.py
-    alpha_vantage_data.py  - helper to fetch fundamentals, technicals, news and economic data from Alpha Vantage
+    alpha_vantage_data.py  - helper to fetch fundamentals, technicals, news and economic data from Alpha Vantage. Includes utilities for income statements, balance sheets and cash flows.
     portfolio_calculations.py
     portfolio_decomposer.py
 scripts


### PR DESCRIPTION
## Summary
- expand AlphaVantageData with helpers to fetch income statement, balance sheet and cash flow data
- add methods to store these fundamentals for many tickers
- provide convenience method to store all fundamental data
- mention new functionality in README

## Testing
- `python -m py_compile classes/alpha_vantage_data.py`

------
https://chatgpt.com/codex/tasks/task_e_6843203146cc832c8d00a2bb5f299454