### PR TITLE
Add utility helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ scripts
 __init__.py
 setup.py
 config.py
+logging_utils.py - helper to configure rotating loggers
+date_utils.py    - pandas-friendly date utilities

--- a/__init__.py
+++ b/__init__.py
@@ -10,3 +10,12 @@ Created on Mon Feb 17 01:07:51 2025
 """
 Portfolio Analytics package
 """
+
+from .logging_utils import get_logger
+from .date_utils import month_end_series, to_yyyymm
+
+__all__ = [
+    "get_logger",
+    "month_end_series",
+    "to_yyyymm",
+]

--- a/date_utils.py
+++ b/date_utils.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Date helpers used throughout the package."""
+
+from __future__ import annotations
+
+from datetime import date as date_type, datetime
+from typing import Iterable
+
+
+def month_end_series(index: Iterable[datetime | str]) -> "pd.DatetimeIndex":
+    """Round each element of ``index`` to month end.
+
+    Parameters
+    ----------
+    index : Iterable of datetimes or strings
+        Values convertible to ``pandas.DatetimeIndex``.
+
+    Returns
+    -------
+    pandas.DatetimeIndex
+        Dates normalized to the last calendar day of the month.
+    """
+    import pandas as pd  # imported lazily for import safety
+
+    idx = pd.DatetimeIndex(index)
+    return idx.to_period("M").to_timestamp("M")
+
+
+def to_yyyymm(dt: datetime | date_type | str) -> int:
+    """Return ``YYYYMM`` integer representation of ``dt``."""
+    if not isinstance(dt, (datetime, date_type)):
+        dt = datetime.fromisoformat(str(dt))
+    return dt.year * 100 + dt.month

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Simple logging helpers for the portfolio analytics package."""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger configured with console and rotating file handlers.
+
+    Parameters
+    ----------
+    name: str
+        Name for the logger and the associated log file ``<name>.log``.
+
+    The logger writes to ``<name>.log`` with a 10 MB limit and keeps three
+    backups. A stream handler is also attached for console output. Handlers are
+    added only once per logger instance.
+    """
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    fmt = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
+    # console
+    console = logging.StreamHandler()
+    console.setFormatter(fmt)
+    logger.addHandler(console)
+
+    # rotating file handler
+    log_file = Path(f"{name}.log")
+    file_handler = RotatingFileHandler(
+        log_file, maxBytes=10 * 1024 * 1024, backupCount=3
+    )
+    file_handler.setFormatter(fmt)
+    logger.addHandler(file_handler)
+
+    return logger


### PR DESCRIPTION
## Summary
- add logging utilities for console+rotating file loggers
- add date helper utilities for month end and YYYYMM conversions
- expose helpers via package `__init__`
- document the new utility modules

## Testing
- `python -m py_compile logging_utils.py date_utils.py __init__.py`
- `python - <<'PY'
import date_utils
print(date_utils.to_yyyymm('2024-02-05'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_684d1b7122dc832cb412e93f2c934a60