### PR TITLE
Add methods to pull ETF profile and holdings 

### DIFF
--- a/classes/data_fetcher.py
+++ b/classes/data_fetcher.py
@@ -41,6 +41,14 @@ class DataFetcher:
             return None
 
     # ------------------------------------------------------------------
+    # ETF data
+    # ------------------------------------------------------------------
+    def fetch_etf_profile(self, symbol: str) -> Dict[str, Any] | None:
+        """Return the ETF profile data for ``symbol``."""
+
+        return self._av_request("ETF_PROFILE", symbol=symbol)
+
+    # ------------------------------------------------------------------
     # database creation / logging
     # ------------------------------------------------------------------
     def create_database(self, db_name: str | None = None) -> None:

--- a/scripts/etf_holdings_example.py
+++ b/scripts/etf_holdings_example.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Example script to fetch and store ETF holdings."""
+
+from typing import List
+
+from config import AV_api_key, AV_db_file
+from classes import DataFetcher, DatabaseAccessor
+
+
+def main(symbols: List[str]) -> None:
+    fetcher = DataFetcher(db_name=AV_db_file, api_key=AV_api_key)
+    accessor = DatabaseAccessor(db_name=AV_db_file)
+
+    for sym in symbols:
+        data = fetcher.fetch_etf_profile(sym)
+        if data:
+            accessor.store_etf_holdings(sym, data)
+            holdings = accessor.get_etf_holdings(sym)
+            print(f"Holdings for {sym}:")
+            print(holdings)
+        else:
+            print(f"Failed to fetch profile for {sym}")
+
+
+if __name__ == "__main__":
+    main(["SPY", "IWV"])


### PR DESCRIPTION
## Summary
- support ETF_PROFILE requests in `DataFetcher`
- store ETF holdings in a new `etf_holdings` table
- expose holdings via `DatabaseAccessor`
- script to fetch and display ETF holdings

## Testing
- `python -m py_compile classes/data_fetcher.py classes/database_accessor.py scripts/etf_holdings_example.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da679e278832c983791299a223986