### PR TITLE
Replace sqlite with SQLAlchemy engine: shift from db file to hosting sql server locally 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql+psycopg://postgres:SuperSecretPW@localhost:5432/av_data_test1

--- a/README.md
+++ b/README.md
@@ -19,3 +19,10 @@ setup.py
 config.py
 logging_utils.py - helper to configure rotating loggers
 date_utils.py    - pandas-friendly date utilities
+
+## Database configuration
+
+Set the `DATABASE_URL` environment variable (see `.env.example`) to point at
+your PostgreSQL or other SQLAlchemy-supported database. The codebase no longer
+uses `sqlite3` directly and now relies on SQLAlchemy for connection pooling and
+database-agnostic queries.

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,3 @@
+from .core import get_engine, get_session
+
+__all__ = ["get_engine", "get_session"]

--- a/db/core.py
+++ b/db/core.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from functools import lru_cache
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "sqlite:///av_data.db",
+)
+
+
+@lru_cache(maxsize=1)
+def get_engine() -> Engine:
+    """Return a singleton SQLAlchemy engine."""
+    return create_engine(DATABASE_URL, future=True)
+
+
+@contextmanager
+def get_session() -> Session:
+    """Provide a transactional SQLAlchemy session."""
+    engine = get_engine()
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    finally:
+        session.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,6 @@ yfinance
 requests
 pandas
 numpy
-sqlite3
+sqlalchemy >= 2.0
+psycopg[binary] >= 3.1
+python - dotenv


### PR DESCRIPTION
## Summary
Major change of shifting database from db file to post gre local server
- add db helpers for global SQLAlchemy engine and session
- refactor DataFetcher to use SQLAlchemy and `pandas.to_sql`
- refactor DatabaseAccessor to read with SQLAlchemy
- add `.env.example` and updated requirements
- document new `DATABASE_URL` env var

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b854f8838832ca378def89d3d45cc