### PR TITLE
Fix update_log handling: grate sqli3 to Postgre

### DIFF
--- a/classes/data_fetcher.py
+++ b/classes/data_fetcher.py
@@ -176,14 +176,6 @@ class DataFetcher:
                 PRIMARY KEY (time_published, ticker)
             )"""
             )
-            conn.exec_driver_sql(
-                """CREATE TABLE IF NOT EXISTS update_log (
-                run_time TEXT,
-                ticker TEXT,
-                table_name TEXT,
-                PRIMARY KEY (run_time, ticker, table_name)
-            )"""
-            )
         # Engine connections are automatically closed
 
     def _log_update(self, ticker: str, table: str, db_name: str | None = None) -> None:
@@ -191,9 +183,9 @@ class DataFetcher:
         with engine.begin() as conn:
             conn.execute(
                 text(
-                    "INSERT INTO update_log (run_time, ticker, table_name) VALUES (NOW(), :ticker, :tbl)"
+                    "INSERT INTO update_log (run_time, ticker, table_name) VALUES (:run_time, :ticker, :tbl)"
                 ),
-                {"ticker": ticker, "tbl": table},
+                {"run_time": datetime.utcnow(), "ticker": ticker, "tbl": table},
             )
 
     # ------------------------------------------------------------------

--- a/db/core.py
+++ b/db/core.py
@@ -14,24 +14,32 @@ DATABASE_URL = os.getenv(
     "postgresql+psycopg://postgres:Secret@localhost:5432/trading_data",
 )
 
+_tables_initialized = False
+
 
 @lru_cache(maxsize=1)
 def get_engine() -> Engine:
-    """Return a singleton SQLAlchemy engine."""
-    return create_engine(DATABASE_URL, future=True)
+    """Return a singleton SQLAlchemy engine and ensure tables exist."""
+    engine = create_engine(DATABASE_URL, future=True)
+    global _tables_initialized
+    if not _tables_initialized:
+        ensure_tables(engine)
+        _tables_initialized = True
+    return engine
 
 
-def ensure_tables() -> None:
+def ensure_tables(engine: Engine | None = None) -> None:
     """Create required tables if they do not exist."""
-    engine = get_engine()
+    if engine is None:
+        engine = get_engine()
     with engine.begin() as conn:
         conn.execute(
             text(
                 """
                 CREATE TABLE IF NOT EXISTS update_log (
-                    run_time TIMESTAMPTZ,
-                    ticker TEXT,
-                    table_name TEXT,
+                    run_time TIMESTAMPTZ NOT NULL,
+                    ticker TEXT NOT NULL,
+                    table_name TEXT NOT NULL,
                     PRIMARY KEY (run_time, ticker, table_name)
                 )
                 """

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -2,8 +2,11 @@ import importlib.util
 import types
 from pathlib import Path
 from sqlalchemy import text
+import sys
 
 root = Path(__file__).resolve().parents[1]
+
+sys.path.insert(0, str(root))
 
 pkg = types.ModuleType("portfolio_analytics")
 pkg.__path__ = [str(root)]
@@ -20,8 +23,6 @@ spec_df = importlib.util.spec_from_file_location(
 classes_pkg = types.ModuleType("portfolio_analytics.classes")
 classes_pkg.__path__ = [str(root / "classes")]
 DataFetcher_mod = importlib.util.module_from_spec(spec_df)
-
-import sys
 
 sys.modules["portfolio_analytics"] = pkg
 sys.modules["portfolio_analytics.db.core"] = core


### PR DESCRIPTION
## Summary
- ensure shared Postgres engine always initializes `update_log`
- remove `update_log` table creation from DataFetcher
- log updates with explicit timestamp parameter
- update test helpers to add repo path to `sys.path`
- test table creation and logging

## Testing
- `black -q classes/data_fetcher.py db/core.py tests/test_update_log.py tests/test_postgres.py`
- `pytest -q` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685cdd151f78832c970eb6ad83fffc97